### PR TITLE
fix: pass remaining options to n3 parser

### DIFF
--- a/lib/ParserStream.js
+++ b/lib/ParserStream.js
@@ -3,7 +3,7 @@ import toReadable from 'duplex-to/readable.js'
 import { StreamParser } from 'n3'
 
 class ParserStream {
-  constructor (input, { baseIRI = '', factory = rdf } = {}) {
+  constructor (input, { baseIRI = '', factory = rdf, ...rest } = {}) {
     const boundFactory = {
       blankNode: factory.blankNode.bind(factory),
       defaultGraph: factory.defaultGraph.bind(factory),
@@ -12,7 +12,7 @@ class ParserStream {
       quad: factory.quad.bind(factory)
     }
 
-    const parser = new StreamParser({ baseIRI, factory: boundFactory })
+    const parser = new StreamParser({ baseIRI, factory: boundFactory, ...rest })
 
     input.pipe(parser)
 

--- a/test/test.js
+++ b/test/test.js
@@ -96,7 +96,7 @@ describe('@rdfjs/parser-n3', () => {
       strictEqual(error.message.includes('literal'), true)
     })
 
-    it('should forward options to n3 parser', async () => {
+    it('should forward blankNodePrefix option to n3 parser', async () => {
       const nt = '<http://example.org/subject> <http://example.org/predicate> _:namedBlank .'
       const parser = new N3Parser()
 

--- a/test/test.js
+++ b/test/test.js
@@ -95,5 +95,16 @@ describe('@rdfjs/parser-n3', () => {
       strictEqual(typeof error, 'object')
       strictEqual(error.message.includes('literal'), true)
     })
+
+    it('should forward options to n3 parser', async () => {
+      const nt = '<http://example.org/subject> <http://example.org/predicate> _:namedBlank .'
+      const parser = new N3Parser()
+
+      const stream = parser.import(Readable.from(nt), { blankNodePrefix: '' })
+
+      const [quad] = await chunks(stream)
+
+      strictEqual(quad.object.value, 'namedBlank')
+    })
   })
 })


### PR DESCRIPTION
I wanted to use n3's `blankNodePrefix` option but found that options are not forwarded to the underlying parser

This ensures that everything will be passed on